### PR TITLE
Added configurable gen_module

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ Manifold.send(self(), :hello)
 Manifold.send([self(), self()], :hello)
 ```
 
+### Configuration
+Manifold takes a single configuration option, which sets the module it dispatches to to actually call send. The default
+is GenServer. To set this variable, add the following to your `config.exs`:
+
+```elixir
+config :manifold, gen_module: MyGenModule
+```
+
+In the above instance, `MyGenModule` must define a `send/2` function that matches the types of `GenServer.send`.
+
+
 ## License
 
 Manifold is released under [the MIT License](LICENSE).

--- a/lib/manifold/worker.ex
+++ b/lib/manifold/worker.ex
@@ -1,6 +1,8 @@
 defmodule Manifold.Worker do
   use GenServer
 
+  @gen_module Application.get_env(:manifold, :gen_module, GenServer)
+
   ## Client
 
   @spec start_link :: GenServer.on_start
@@ -10,7 +12,7 @@ defmodule Manifold.Worker do
 
   @spec send(pid, [pid], term) :: :ok
   def send(pid, pids, message) do
-    GenServer.cast(pid, {:send, pids, message})
+    @gen_module.cast(pid, {:send, pids, message})
   end
 
   ## Server Callbacks


### PR DESCRIPTION
We need to be able to swap out the GenServer module with our own
implementation so that we can avoid reconnect behavior. This allows
people to swap out the module used to send messages.