### PR TITLE
[manifold] make partitioner faster. 

### DIFF
--- a/bench/group_by_bench.exs
+++ b/bench/group_by_bench.exs
@@ -4,7 +4,7 @@ defmodule GroupByBench do
   alias Manifold.Utils
 
   setup_all do
-    pids = for _ <- 0..1000 do
+    pids = for _ <- 0..5000 do
       spawn_link &loop/0
     end
 
@@ -17,12 +17,28 @@ defmodule GroupByBench do
     end
   end
 
-  bench "group by" do
+  bench "group by 48" do
     bench_context |> Utils.group_by(&:erlang.phash2(&1, 48))
   end
 
-  bench "partition_pids" do
+  bench "partition_pids 48" do
     bench_context |> Utils.partition_pids(48)
+  end
+
+  bench "group by 24" do
+    bench_context |> Utils.group_by(&:erlang.phash2(&1, 24))
+  end
+
+  bench "partition_pids 24" do
+    bench_context |> Utils.partition_pids(24)
+  end
+
+  bench "group by 8" do
+    bench_context |> Utils.group_by(&:erlang.phash2(&1, 8))
+  end
+
+  bench "partition_pids 8" do
+    bench_context |> Utils.partition_pids(8)
   end
 
 

--- a/bench/group_by_bench.exs
+++ b/bench/group_by_bench.exs
@@ -1,0 +1,30 @@
+defmodule GroupByBench do
+  use Benchfella
+
+  alias Manifold.Utils
+
+  setup_all do
+    pids = for _ <- 0..1000 do
+      spawn_link &loop/0
+    end
+
+    {:ok, _} = Manifold.Partitioner.start_link(8, name: Manifold.Partitioner)
+    {:ok, pids}
+  end
+
+  defp loop() do
+    receive do
+      _ -> loop()
+    end
+  end
+
+  bench "group by with tuple" do
+    bench_context |> Utils.partition_pids(48)
+  end
+
+  bench "manifold send" do
+    Manifold.send(bench_context, :hello)
+  end
+
+
+end

--- a/bench/group_by_bench.exs
+++ b/bench/group_by_bench.exs
@@ -4,10 +4,7 @@ defmodule GroupByBench do
   alias Manifold.Utils
 
   setup_all do
-    pids = for _ <- 0..5000 do
-      spawn_link &loop/0
-    end
-
+    pids = for _ <- 0..5000, do: spawn_link &loop/0
     {:ok, pids}
   end
 

--- a/bench/group_by_bench.exs
+++ b/bench/group_by_bench.exs
@@ -8,7 +8,6 @@ defmodule GroupByBench do
       spawn_link &loop/0
     end
 
-    {:ok, _} = Manifold.Partitioner.start_link(8, name: Manifold.Partitioner)
     {:ok, pids}
   end
 
@@ -18,12 +17,12 @@ defmodule GroupByBench do
     end
   end
 
-  bench "group by with tuple" do
-    bench_context |> Utils.partition_pids(48)
+  bench "group by" do
+    bench_context |> Utils.group_by(&:erlang.phash2(&1, 48))
   end
 
-  bench "manifold send" do
-    Manifold.send(bench_context, :hello)
+  bench "partition_pids" do
+    bench_context |> Utils.partition_pids(48)
   end
 
 

--- a/bench/group_by_one.exs
+++ b/bench/group_by_one.exs
@@ -1,10 +1,11 @@
-defmodule GroupByBench do
+defmodule GroupByOneBench do
   use Benchfella
 
   alias Manifold.Utils
 
   setup_all do
-    pids = for _ <- 0..5000, do: spawn_link &loop/0
+    pids = [spawn_link &loop/0]
+
     {:ok, pids}
   end
 
@@ -13,6 +14,7 @@ defmodule GroupByBench do
       _ -> loop()
     end
   end
+
 
   bench "group by 48" do
     bench_context
@@ -43,6 +45,4 @@ defmodule GroupByBench do
     bench_context
     |> Utils.partition_pids(8)
   end
-
-
 end

--- a/bench/partitioner_benches.exs
+++ b/bench/partitioner_benches.exs
@@ -1,0 +1,78 @@
+defmodule WorkerSendBenches do
+  use Benchfella
+
+  alias Manifold.Utils
+
+  defmodule Worker do
+    use GenServer
+
+    ## Client
+    @spec start_link :: GenServer.on_start
+    def start_link, do: GenServer.start_link(__MODULE__, [])
+
+    @spec send(pid, [pid], term) :: :ok
+    def send(pid, pids, message), do: GenServer.cast(pid, {:send, pids, message})
+
+    ## Server Callbacks
+    @spec init([]) :: {:ok, nil}
+    def init([]), do: {:ok, nil}
+
+    def handle_cast({:send, _pids, _message}, nil) do
+      {:noreply, nil}
+    end
+
+    def handle_cast(_message, nil), do: {:noreply, nil}
+  end
+
+
+  setup_all do
+    workers = (for _ <- 0..15, do: Worker.start_link() |> elem(1)) |> List.to_tuple
+    pids = for _ <- 0..200, do: spawn_link &loop/0
+
+    pids_by_partition = Utils.partition_pids(pids, tuple_size(workers))
+    pids_by_partition_map = Utils.group_by(pids, &Utils.partition_for(&1, tuple_size(workers)))
+
+    {:ok, {workers, pids_by_partition, pids_by_partition_map}}
+  end
+
+  defp loop() do
+    receive do
+      _ -> loop()
+    end
+  end
+
+  bench "enum reduce send" do
+    {workers, _, pids_by_partition_map} = bench_context
+    Enum.reduce(pids_by_partition_map, workers, fn ({partition, pids}, state) ->
+      {worker_pid, state} = get_worker_pid(partition, state)
+      Worker.send(worker_pid, pids, :hi)
+      state
+    end)
+  end
+
+  bench "do_send send" do
+    {workers, pids_by_partition, _} = bench_context
+    do_send(:hi, pids_by_partition, workers, 0, tuple_size(pids_by_partition))
+  end
+
+  defp get_worker_pid(partition, state) do
+    case elem(state, partition) do
+      nil ->
+        {:ok, pid} = Worker.start_link()
+        {pid, put_elem(state, partition, pid)}
+      pid ->
+        {pid, state}
+    end
+  end
+
+  defp do_send(_message, _pids_by_partition, _workers, partitions, partitions), do: :ok
+  defp do_send(message, pids_by_partition, workers, partition, partitions) do
+    pids = elem(pids_by_partition, partition)
+    if pids != [] do
+      Worker.send(elem(workers, partition), pids, message)
+    end
+    do_send(message, pids_by_partition, workers, partition + 1, partitions)
+  end
+
+
+end

--- a/bench/partitioner_benches_one.exs
+++ b/bench/partitioner_benches_one.exs
@@ -1,4 +1,4 @@
-defmodule WorkerSendBenches do
+defmodule WorkerSendOneBenches do
   use Benchfella
 
   alias Manifold.Utils
@@ -26,8 +26,8 @@ defmodule WorkerSendBenches do
 
 
   setup_all do
-    workers = (for _ <- 0..15, do: Worker.start_link() |> elem(1)) |> List.to_tuple
-    pids = for _ <- 0..200, do: spawn_link &loop/0
+    workers = (for _ <- 0..47, do: Worker.start_link() |> elem(1)) |> List.to_tuple
+    pids = [spawn_link &loop/0]
 
     pids_by_partition = Utils.partition_pids(pids, tuple_size(workers))
     pids_by_partition_map = Utils.group_by(pids, &Utils.partition_for(&1, tuple_size(workers)))

--- a/bench/send_bench.exs
+++ b/bench/send_bench.exs
@@ -1,0 +1,38 @@
+defmodule SendBench do
+  use Benchfella
+
+  alias Manifold.Utils
+
+  setup_all do
+    pids = for _ <- 0..14 do
+      spawn_link &loop/0
+    end
+
+    {:ok, pids}
+  end
+
+  defp loop() do
+    receive do
+      _ -> loop()
+    end
+  end
+
+  bench "send enum each" do
+    bench_context |> Enum.each(&send(&1, :hi))
+  end
+
+  bench "send list comp" do
+    for pid <- bench_context, do: send(pid, :hi)
+  end
+
+  bench "send fast reducer" do
+    send_r(bench_context, :hi)
+  end
+
+  defp send_r([], _msg), do: :ok
+  defp send_r([pid | pids], msg) do
+    send(pid, msg)
+    send_r(pids, msg)
+  end
+
+end

--- a/bench/send_bench.exs
+++ b/bench/send_bench.exs
@@ -4,9 +4,7 @@ defmodule SendBench do
   alias Manifold.Utils
 
   setup_all do
-    pids = for _ <- 0..14 do
-      spawn_link &loop/0
-    end
+    pids = for _ <- 0..200, do: spawn_link &loop/0
 
     {:ok, pids}
   end

--- a/bench/send_bench_one.exs
+++ b/bench/send_bench_one.exs
@@ -1,11 +1,9 @@
 defmodule SendBenchOne do
   use Benchfella
 
-  alias Manifold.Utils
-
   setup_all do
-    pids = [spawn_link &loop/0]
-    {:ok, pids}
+    pid = spawn_link &loop/0
+    {:ok, pid}
   end
 
   defp loop() do
@@ -15,20 +13,19 @@ defmodule SendBenchOne do
   end
 
   bench "send enum each" do
-    bench_context |> Enum.each(&send(&1, :hi))
+    [bench_context] |> Enum.each(&send(&1, :hi))
   end
 
   bench "send list comp" do
-    for pid <- bench_context, do: send(pid, :hi)
+    for pid <- [bench_context], do: send(pid, :hi)
   end
 
   bench "send one" do
-    [pid] = bench_context
-    send(pid, :hi)
+    send(bench_context, :hi)
   end
 
   bench "send fast reducer" do
-    send_r(bench_context, :hi)
+    send_r([bench_context], :hi)
   end
 
   defp send_r([], _msg), do: :ok

--- a/bench/send_bench_one.exs
+++ b/bench/send_bench_one.exs
@@ -1,0 +1,40 @@
+defmodule SendBenchOne do
+  use Benchfella
+
+  alias Manifold.Utils
+
+  setup_all do
+    pids = [spawn_link &loop/0]
+    {:ok, pids}
+  end
+
+  defp loop() do
+    receive do
+      _ -> loop()
+    end
+  end
+
+  bench "send enum each" do
+    bench_context |> Enum.each(&send(&1, :hi))
+  end
+
+  bench "send list comp" do
+    for pid <- bench_context, do: send(pid, :hi)
+  end
+
+  bench "send one" do
+    [pid] = bench_context
+    send(pid, :hi)
+  end
+
+  bench "send fast reducer" do
+    send_r(bench_context, :hi)
+  end
+
+  defp send_r([], _msg), do: :ok
+  defp send_r([pid | pids], msg) do
+    send(pid, msg)
+    send_r(pids, msg)
+  end
+
+end

--- a/lib/manifold.ex
+++ b/lib/manifold.ex
@@ -23,7 +23,7 @@ defmodule Manifold do
 
   ## Client
 
-  @spec send([pid], term) :: :ok
+  @spec send([pid | nil] | pid | nil, term) :: :ok
   def send(pids, message) when is_list(pids) do
     pids
       |> Utils.group_by(fn
@@ -35,9 +35,6 @@ defmodule Manifold do
         {node, pids} -> Partitioner.send({Partitioner, node}, pids, message)
       end)
   end
-
-  @spec send(pid, term) :: :ok
-  def send(pid, message) do
-    __MODULE__.send([pid], message)
-  end
+  def send(pid, message) when is_pid(pid), do: Partitioner.send({Partitioner, node(pid)}, [pid], message)
+  def send(nil, message), do: :ok
 end

--- a/lib/manifold.ex
+++ b/lib/manifold.ex
@@ -33,5 +33,5 @@ defmodule Manifold do
     for {node, pids} <- grouped_by, node != nil, do: Partitioner.send({Partitioner, node}, pids, message)
   end
   def send(pid, message) when is_pid(pid), do: Partitioner.send({Partitioner, node(pid)}, [pid], message)
-  def send(nil, message), do: :ok
+  def send(nil, _message), do: :ok
 end

--- a/lib/manifold.ex
+++ b/lib/manifold.ex
@@ -24,9 +24,9 @@ defmodule Manifold do
   ## Client
 
   @spec send([pid | nil] | pid | nil, term) :: :ok
-  def send([pid], message), do: send(pid, message)
+  def send([pid], message), do: __MODULE__.send(pid, message)
   def send(pids, message) when is_list(pids) do
-    grouped_by = Utils.group_by(fn
+    grouped_by = Utils.group_by(pids, fn
       nil -> nil
       pid -> node(pid)
     end)

--- a/lib/manifold.ex
+++ b/lib/manifold.ex
@@ -24,6 +24,7 @@ defmodule Manifold do
   ## Client
 
   @spec send([pid | nil] | pid | nil, term) :: :ok
+  def send([pid], message), do: send(pid, message)
   def send(pids, message) when is_list(pids) do
     pids
       |> Utils.group_by(fn

--- a/lib/manifold/partitioner.ex
+++ b/lib/manifold/partitioner.ex
@@ -58,6 +58,12 @@ defmodule Manifold.Partitioner do
     {:reply, :error, state}
   end
 
+  # Specialize handling cast to a single pid.
+  def handle_cast({:send, [pid], message}, state) do
+    partition = Utils.partition_for(pid, tuple_size(state))
+    Worker.send(elem(state, partition), [pid], message)
+    {:noreply, state}
+  end
   def handle_cast({:send, pids, message}, state) do
     partitions = tuple_size(state)
     pids_by_partition = Utils.partition_pids(pids, partitions)

--- a/lib/manifold/partitioner.ex
+++ b/lib/manifold/partitioner.ex
@@ -31,7 +31,11 @@ defmodule Manifold.Partitioner do
     # Set optimal process flags
     Process.flag(:trap_exit, true)
     Process.flag(:message_queue_data, :off_heap)
-    {:ok, Tuple.duplicate(nil, partitions)}
+    workers = for _ <- 0..partitions do
+      {:ok, pid} = Worker.start_link()
+      pid
+    end
+    {:ok, List.to_tuple(workers)}
   end
 
   def terminate(_reason, _state), do: :ok
@@ -55,13 +59,9 @@ defmodule Manifold.Partitioner do
   end
 
   def handle_cast({:send, pids, message}, state) do
-    state = pids
-      |> Utils.group_by(&:erlang.phash2(&1, tuple_size(state)))
-      |> Enum.reduce(state, fn ({partition, pids}, state) ->
-        {worker_pid, state} = get_worker_pid(partition, state)
-        Worker.send(worker_pid, pids, message)
-        state
-      end)
+    partitions = tuple_size(state)
+    pids_by_partition = Utils.partition_pids(pids, partitions)
+    do_send(message, pids_by_partition, state, 0, partitions)
     {:noreply, state}
   end
   def handle_cast(_message, state) do
@@ -85,15 +85,12 @@ defmodule Manifold.Partitioner do
     {:noreply, state}
   end
 
-  ## Private
-
-  defp get_worker_pid(partition, state) do
-    case elem(state, partition) do
-      nil ->
-        {:ok, pid} = Worker.start_link
-        {pid, put_elem(state, partition, pid)}
-      pid ->
-        {pid, state}
+  defp do_send(_message, _pids_by_partition, _workers, partitions, partitions), do: :ok
+  defp do_send(message, pids_by_partition, workers, partition, partitions) do
+    pids = elem(pids_by_partition, partition)
+    if pids != [] do
+      Worker.send(elem(workers, partition), pids, message)
     end
+    do_send(message, pids_by_partition, workers, partition + 1, partitions)
   end
 end

--- a/lib/manifold/partitioner.ex
+++ b/lib/manifold/partitioner.ex
@@ -74,7 +74,7 @@ defmodule Manifold.Partitioner do
     state = state
       |> Tuple.to_list
       |> Enum.map(fn
-        ^pid -> nil
+        ^pid -> Worker.start_link()
         pid -> pid
       end)
       |> List.to_tuple

--- a/lib/manifold/partitioner.ex
+++ b/lib/manifold/partitioner.ex
@@ -46,6 +46,7 @@ defmodule Manifold.Partitioner do
     end
     {:reply, children, state}
   end
+
   def handle_call(:count_children, _from, state) do
     {:reply, [
       specs: 1,
@@ -54,6 +55,7 @@ defmodule Manifold.Partitioner do
       workers: tuple_size(state)
     ], state}
   end
+
   def handle_call(_message, _from, state) do
     {:reply, :error, state}
   end
@@ -64,12 +66,14 @@ defmodule Manifold.Partitioner do
     Worker.send(elem(state, partition), [pid], message)
     {:noreply, state}
   end
+
   def handle_cast({:send, pids, message}, state) do
     partitions = tuple_size(state)
     pids_by_partition = Utils.partition_pids(pids, partitions)
     do_send(message, pids_by_partition, state, 0, partitions)
     {:noreply, state}
   end
+
   def handle_cast(_message, state) do
     {:noreply, state}
   end
@@ -87,6 +91,7 @@ defmodule Manifold.Partitioner do
 
     {:noreply, state}
   end
+
   def handle_info(_message, state) do
     {:noreply, state}
   end

--- a/lib/manifold/utils.ex
+++ b/lib/manifold/utils.ex
@@ -31,7 +31,7 @@ defmodule Manifold.Utils do
   end
   defp do_partition_pids([], _partitions, pids_by_partition), do: pids_by_partition
 
-  @"""
+  @doc """
   Computes the partition for a given pid using :erlang.phash2/2
   """
   @spec partition_for(pid, integer) :: integer

--- a/lib/manifold/utils.ex
+++ b/lib/manifold/utils.ex
@@ -9,12 +9,12 @@ defmodule Manifold.Utils do
   def group_by(pids, key_fun), do: group_by(pids, key_fun, %{})
 
   @spec group_by([pid], key_fun, groups) :: groups
-  def group_by([pid | pids], key_fun, groups) do
+  defp group_by([pid | pids], key_fun, groups) do
     key = key_fun.(pid)
     group = Map.get(groups, key, [])
     group_by(pids, key_fun, Map.put(groups, key, [pid | group]))
   end
-  def group_by([], _key_fun, groups), do: groups
+  defp group_by([], _key_fun, groups), do: groups
 
   @doc """
   Partitions a bunch of pids into a tuple, of lists of pids grouped by by the result of :erlang.pash2/2
@@ -31,6 +31,9 @@ defmodule Manifold.Utils do
   end
   defp do_partition_pids([], _partitions, pids_by_partition), do: pids_by_partition
 
+  @"""
+  Computes the partition for a given pid using :erlang.phash2/2
+  """
   @spec partition_for(pid, integer) :: integer
   def partition_for(pid, partitions) do
     :erlang.phash2(pid, partitions)

--- a/lib/manifold/utils.ex
+++ b/lib/manifold/utils.ex
@@ -6,7 +6,7 @@ defmodule Manifold.Utils do
   A faster version of Enum.group_by with less bells and whistles.
   """
   @spec group_by([pid], key_fun) :: groups
-  def group_by(pids, key_fun), do: group_by(pids, key_fun, Map.new)
+  def group_by(pids, key_fun), do: group_by(pids, key_fun, %{})
 
   @spec group_by([pid], key_fun, groups) :: groups
   def group_by([pid | pids], key_fun, groups) do

--- a/lib/manifold/utils.ex
+++ b/lib/manifold/utils.ex
@@ -25,9 +25,14 @@ defmodule Manifold.Utils do
   end
 
   defp do_partition_pids([pid | pids], partitions, pids_by_partition) do
-    partition = :erlang.phash2(pid, partitions)
+    partition = partition_for(pid, partitions)
     pids_in_partition = elem(pids_by_partition, partition)
     do_partition_pids(pids, partitions, put_elem(pids_by_partition, partition, [pid | pids_in_partition]))
   end
   defp do_partition_pids([], _partitions, pids_by_partition), do: pids_by_partition
+
+  @spec partition_for(pid, integer) :: integer
+  def partition_for(pid, partitions) do
+    :erlang.phash2(pid, partitions)
+  end
 end

--- a/lib/manifold/utils.ex
+++ b/lib/manifold/utils.ex
@@ -11,7 +11,7 @@ defmodule Manifold.Utils do
   @spec group_by([pid], key_fun, groups) :: groups
   def group_by([pid | pids], key_fun, groups) do
     key = key_fun.(pid)
-    group = Map.get(groups, key) || []
+    group = Map.get(groups, key, [])
     group_by(pids, key_fun, Map.put(groups, key, [pid | group]))
   end
   def group_by([], _key_fun, groups), do: groups

--- a/lib/manifold/utils.ex
+++ b/lib/manifold/utils.ex
@@ -9,10 +9,25 @@ defmodule Manifold.Utils do
   def group_by(pids, key_fun), do: group_by(pids, key_fun, Map.new)
 
   @spec group_by([pid], key_fun, groups) :: groups
-  def group_by([pid|pids], key_fun, groups) do
+  def group_by([pid | pids], key_fun, groups) do
     key = key_fun.(pid)
     group = Map.get(groups, key) || []
-    group_by(pids, key_fun, Map.put(groups, key, [pid|group]))
+    group_by(pids, key_fun, Map.put(groups, key, [pid | group]))
   end
   def group_by([], _key_fun, groups), do: groups
+
+  @doc """
+  Partitions a bunch of pids into a tuple, of lists of pids grouped by by the result of :erlang.pash2/2
+  """
+  @spec partition_pids([pid], integer) :: tuple
+  def partition_pids(pids, partitions) do
+    do_partition_pids(pids, partitions, Tuple.duplicate([], partitions))
+  end
+
+  defp do_partition_pids([pid | pids], partitions, pids_by_partition) do
+    partition = :erlang.phash2(pid, partitions)
+    pids_in_partition = elem(pids_by_partition, partition)
+    do_partition_pids(pids, partitions, put_elem(pids_by_partition, partition, [pid | pids_in_partition]))
+  end
+  defp do_partition_pids([], _partitions, pids_by_partition), do: pids_by_partition
 end

--- a/lib/manifold/worker.ex
+++ b/lib/manifold/worker.ex
@@ -14,9 +14,12 @@ defmodule Manifold.Worker do
   end
 
   ## Server Callbacks
-
+  def handle_cast({:send, [pid], message}, state) do
+    send(pid, message)
+    {:noreply, state}
+  end
   def handle_cast({:send, pids, message}, state) do
-    Enum.each(pids, &send(&1, message))
+    for pid <- pids, do: send(pid, message)
     {:noreply, state}
   end
 

--- a/lib/manifold/worker.ex
+++ b/lib/manifold/worker.ex
@@ -2,28 +2,25 @@ defmodule Manifold.Worker do
   use GenServer
 
   ## Client
-
   @spec start_link :: GenServer.on_start
-  def start_link do
-    GenServer.start_link(__MODULE__, [:ok])
-  end
+  def start_link, do: GenServer.start_link(__MODULE__, [])
 
   @spec send(pid, [pid], term) :: :ok
-  def send(pid, pids, message) do
-    GenServer.cast(pid, {:send, pids, message})
-  end
+  def send(pid, pids, message), do: GenServer.cast(pid, {:send, pids, message})
 
   ## Server Callbacks
-  def handle_cast({:send, [pid], message}, state) do
+  @spec init([]) :: {:ok, nil}
+  def init([]), do: {:ok, nil}
+
+  def handle_cast({:send, [pid], message}, nil) do
     send(pid, message)
-    {:noreply, state}
-  end
-  def handle_cast({:send, pids, message}, state) do
-    for pid <- pids, do: send(pid, message)
-    {:noreply, state}
+    {:noreply, nil}
   end
 
-  def handle_cast(_message, state) do
-    {:noreply, state}
+  def handle_cast({:send, pids, message}, nil) do
+    for pid <- pids, do: send(pid, message)
+    {:noreply, nil}
   end
+
+  def handle_cast(_message, nil), do: {:noreply, nil}
 end

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,9 @@ defmodule Manifold.Mixfile do
   end
 
   defp deps do
-    []
+    [
+      {:benchfella, "~> 0.3.0"}
+    ]
   end
 
   def package do

--- a/test/manifold_test.exs
+++ b/test/manifold_test.exs
@@ -38,7 +38,7 @@ defmodule ManifoldTest do
         message -> send(me, message)
       end
     end
-    Manifold.send([pid], message)
+    Manifold.send(pid, message)
     assert_receive ^message
   end
 

--- a/test/manifold_test.exs
+++ b/test/manifold_test.exs
@@ -18,7 +18,7 @@ defmodule ManifoldTest do
     end
   end
 
-  test "send one" do
+  test "send to list of one" do
     me = self()
     message = :hello
     pid = spawn_link fn ->
@@ -27,6 +27,35 @@ defmodule ManifoldTest do
       end
     end
     Manifold.send([pid], message)
+    assert_receive ^message
+  end
+
+  test "send to one" do
+    me = self()
+    message = :hello
+    pid = spawn_link fn ->
+      receive do
+        message -> send(me, message)
+      end
+    end
+    Manifold.send([pid], message)
+    assert_receive ^message
+  end
+
+  test "send to nil" do
+    assert Manifold.send([nil], :hi) == :ok
+    assert Manifold.send(nil, :hi) == :ok
+  end
+
+  test "send with nil in list wont blow up" do
+    me = self()
+    message = :hello
+    pid = spawn_link fn ->
+      receive do
+        message -> send(me, message)
+      end
+    end
+    Manifold.send([nil, pid, nil], message)
     assert_receive ^message
   end
 end

--- a/test/manifold_test.exs
+++ b/test/manifold_test.exs
@@ -6,7 +6,7 @@ defmodule ManifoldTest do
     me = self()
     message = :hello
     pids = for _ <- 0..10000 do
-      spawn fn ->
+      spawn_link fn ->
         receive do
           message -> send(me, {self(), message})
         end
@@ -16,5 +16,17 @@ defmodule ManifoldTest do
     for pid <- pids do
       assert_receive {^pid, ^message}
     end
+  end
+
+  test "send one" do
+    me = self()
+    message = :hello
+    pid = spawn_link fn ->
+      receive do
+        message -> send(me, message)
+      end
+    end
+    Manifold.send([pid], message)
+    assert_receive ^message
   end
 end


### PR DESCRIPTION
## Partitioner Optimizations

- [x] instead of `Utils.group_by`, we are using a new function called `Utils.partition_pids` which uses a tuple instead of a map internally. This ends up being roughly 2.2x faster than `Utils.group_by` in the benchmarks attached. 

```
## GroupByBench
benchmark name     iterations   average time
partition_pids 8         5000   340.75 µs/op
partition_pids 24        5000   382.38 µs/op
partition_pids 48        5000   432.45 µs/op
group by 8               5000   600.24 µs/op
group by 24              2000   730.41 µs/op
group by 48              1000   1154.78 µs/op
```

- [x] make `state` not need to be modified during iteration. (pre-spawn the workers) in the Partitioner. This means we don't have to use `Enum.reduce` and can instead use a more optimized code path for this, `do_send`, which operates on a tuple of lists, and sends to the respective worker. Turns out this isn't really any faster...

```
## WorkerSendBenches
benchmark name    iterations   average time
enum reduce send       50000   65.56 µs/op
do_send send           50000   68.85 µs/op
```

- [x] add a specific case for sending to a single pid (which we do quite often, when doing manifold sends to a single pid). There is no practical speedup in avoiding the group by operation, but the resultant `send` operation ends up being faster, as it doesn't have to start an `Enum.reduce`r, or iterate over the result of `Utils.partition_pids`, so that avoids ~0.15µs/op + ~0.70-1.5 µs/op. additionally, this function consumes less reductions as it is doing less things (which we want!)

```
## GroupByOneBench
benchmark name     iterations   average time
partition_pids 8     10000000   0.11 µs/op
partition_pids 24    10000000   0.14 µs/op
group by 48          10000000   0.14 µs/op
group by 8           10000000   0.14 µs/op
group by 24          10000000   0.16 µs/op
partition_pids 48    10000000   0.20 µs/op

## WorkerSendOneBenches (worker count=48)
benchmark name    iterations   average time
enum reduce send    10000000   0.70 µs/op
do_send send         1000000   1.47 µs/op
```

## worker gained some optimizations too:
- [x] use list comprehension instead of `Enum.each` (it's a little bit faster), here's sending to 200 pids:

```
## SendBench
benchmark name     iterations   average time
send list comp           2000   961.87 µs/op
send fast reducer        2000   982.81 µs/op
send enum each           1000   1153.00 µs/op
```

- [x] add a special case for sending to a single pid:

```
## SendBenchOne
benchmark name     iterations   average time
send one             10000000   0.22 µs/op
send fast reducer    10000000   0.27 µs/op
send enum each       10000000   0.34 µs/op
send list comp       10000000   0.34 µs/op
``` 

## Manifold.send
- [x] make a specialized code path for sending to a single pid.
- [x] use list comprehension instead of Enum.each