### PR TITLE
[manifold] shard the partitioner

### DIFF
--- a/lib/manifold.ex
+++ b/lib/manifold.ex
@@ -3,17 +3,18 @@ defmodule Manifold do
 
   alias Manifold.{Partitioner, Utils}
 
+  @max_partitioners 32
+  @online_partitioners Application.get_env(:manifold, :online_partitioners, 4)
+  @workers_per_partitioner Application.get_env(:manifold, :workers_per_partitioner, Integer.floor_div(System.schedulers_online, 2))
+
   ## OTP
 
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
 
-    # Spawn partitions based on number of schedlers (CPU cores).
-    partitions = System.schedulers_online
-
-    children = [
-      Partitioner.child_spec(partitions, [name: Partitioner]),
-    ]
+    children = for partitioner_id <- 0..(@online_partitioners - 1) do
+      Partitioner.child_spec(@workers_per_partitioner, [name: partitioner_for(partitioner_id)])
+    end
 
     Supervisor.start_link children,
       strategy: :one_for_one,
@@ -26,12 +27,33 @@ defmodule Manifold do
   @spec send([pid | nil] | pid | nil, term) :: :ok
   def send([pid], message), do: __MODULE__.send(pid, message)
   def send(pids, message) when is_list(pids) do
+    partitioner_name = current_partitioner()
     grouped_by = Utils.group_by(pids, fn
       nil -> nil
       pid -> node(pid)
     end)
-    for {node, pids} <- grouped_by, node != nil, do: Partitioner.send({Partitioner, node}, pids, message)
+    for {node, pids} <- grouped_by, node != nil, do: Partitioner.send({partitioner_name, node}, pids, message)
+    :ok
   end
-  def send(pid, message) when is_pid(pid), do: Partitioner.send({Partitioner, node(pid)}, [pid], message)
+  def send(pid, message) when is_pid(pid), do: Partitioner.send({current_partitioner(), node(pid)}, [pid], message)
   def send(nil, _message), do: :ok
+
+  def current_partitioner() do
+    partitioner_for(self())
+  end
+
+  def partitioner_for(pid) when is_pid(pid) do
+    pid
+    |> Utils.partition_for(@online_partitioners)
+    |> partitioner_for
+  end
+
+  # The 0th partitioner does not have a number in it's process name for backwards compatibility
+  # purposes.
+  def partitioner_for(0), do: Manifold.Partitioner
+  for partitioner_id <- (1..@max_partitioners - 1) do
+    def partitioner_for(unquote(partitioner_id)) do
+      unquote(:"Manifold.Partitioner#{partitioner_id}")
+    end
+  end
 end

--- a/lib/manifold.ex
+++ b/lib/manifold.ex
@@ -4,7 +4,7 @@ defmodule Manifold do
   alias Manifold.{Partitioner, Utils}
 
   @max_partitioners 32
-  @online_partitioners Application.get_env(:manifold, :online_partitioners, 1)
+  @online_partitioners min(Application.get_env(:manifold, :online_partitioners, 1), @max_partitioners)
   @workers_per_partitioner Application.get_env(:manifold, :workers_per_partitioner, System.schedulers_online)
 
   ## OTP

--- a/lib/manifold.ex
+++ b/lib/manifold.ex
@@ -53,7 +53,7 @@ defmodule Manifold do
   def partitioner_for(0), do: Manifold.Partitioner
   for partitioner_id <- (1..@max_partitioners - 1) do
     def partitioner_for(unquote(partitioner_id)) do
-      unquote(:"Manifold.Partitioner#{partitioner_id}")
+      unquote(:"Manifold.Partitioner_#{partitioner_id}")
     end
   end
 end

--- a/lib/manifold.ex
+++ b/lib/manifold.ex
@@ -38,8 +38,17 @@ defmodule Manifold do
   def send(pid, message) when is_pid(pid), do: Partitioner.send({current_partitioner(), node(pid)}, [pid], message)
   def send(nil, _message), do: :ok
 
+  def set_partitioner_key(key) do
+    Process.put(:manifold_partitioner_key, Utils.hash(key))
+  end
+
   def current_partitioner() do
-    partitioner_for(self())
+    partitioner_key = Process.get(:manifold_partitioner_key)
+    if partitioner_key == nil do
+      partitioner_for(self())
+    else
+      partitioner_for(rem(partitioner_key, @online_partitioners))
+    end
   end
 
   def partitioner_for(pid) when is_pid(pid) do

--- a/lib/manifold.ex
+++ b/lib/manifold.ex
@@ -4,8 +4,8 @@ defmodule Manifold do
   alias Manifold.{Partitioner, Utils}
 
   @max_partitioners 32
-  @online_partitioners Application.get_env(:manifold, :online_partitioners, 4)
-  @workers_per_partitioner Application.get_env(:manifold, :workers_per_partitioner, Integer.floor_div(System.schedulers_online, 2))
+  @online_partitioners Application.get_env(:manifold, :online_partitioners, 1)
+  @workers_per_partitioner Application.get_env(:manifold, :workers_per_partitioner, System.schedulers_online)
 
   ## OTP
 

--- a/lib/manifold/partitioner.ex
+++ b/lib/manifold/partitioner.ex
@@ -12,7 +12,7 @@ defmodule Manifold.Partitioner do
   @spec child_spec(Keyword.t) :: tuple
   def child_spec(partitions, opts \\ []) do
     import Supervisor.Spec, warn: false
-    supervisor(__MODULE__, [partitions, opts])
+    supervisor(__MODULE__, [partitions, opts], id: Keyword.get(opts, :name, __MODULE__))
   end
 
   @spec start_link(Number.t, Keyword.t) :: GenServer.on_start

--- a/lib/manifold/utils.ex
+++ b/lib/manifold/utils.ex
@@ -38,4 +38,11 @@ defmodule Manifold.Utils do
   def partition_for(pid, partitions) do
     :erlang.phash2(pid, partitions)
   end
+
+  @spec hash(atom | binary | integer) :: integer
+  def hash(key) when is_binary(key) do
+    <<_ :: binary-size(8), value :: unsigned-little-integer-size(64)>> = :erlang.md5(key)
+    value
+  end
+  def hash(key), do: hash("#{key}")
 end

--- a/test/manifold_test.exs
+++ b/test/manifold_test.exs
@@ -58,4 +58,20 @@ defmodule ManifoldTest do
     Manifold.send([nil, pid, nil], message)
     assert_receive ^message
   end
+
+  test "send with pinned process" do
+    me = self()
+    message = :hello
+    pid = spawn_link fn ->
+      receive do
+        message -> send(me, message)
+      end
+    end
+    assert Process.get(:manifold_partitioner) == nil
+    Manifold.set_partitioner_key("hello")
+    assert Process.get(:manifold_partitioner) == Manifold.Partitioner
+
+    Manifold.send([nil, pid, nil], message)
+    assert_receive ^message
+  end
 end

--- a/test/manifold_test.exs
+++ b/test/manifold_test.exs
@@ -66,12 +66,17 @@ defmodule ManifoldTest do
       receive do
         message -> send(me, message)
       end
+      receive do
+        message -> send(me, message)
+      end
     end
     assert Process.get(:manifold_partitioner) == nil
     Manifold.set_partitioner_key("hello")
     assert Process.get(:manifold_partitioner) == Manifold.Partitioner
 
     Manifold.send([nil, pid, nil], message)
+    Manifold.send(pid, message)
+    assert_receive ^message
     assert_receive ^message
   end
 end


### PR DESCRIPTION
this is just a PoC to the sharding strategy. The idea is to register 4 partitioners with a preset of names, and then send to the correct partitioner in `Manifold.send` based off the pid of what is sending. 

TODO:
- [x] compile time partitioner name generator.
- [x] application config for # partitioners
- [x] application config for # workers per partitioner.
- [x] way to pin a given process by some key to a specific partitioner as it changes pids (our handoff case)