### PR TITLE
Configurable senders, partitioners and workers per partitioner at runtime

### DIFF
--- a/lib/manifold.ex
+++ b/lib/manifold.ex
@@ -127,7 +127,7 @@ defmodule Manifold do
 
   def partitioner_for(pid) when is_pid(pid) do
     pid
-    |> Utils.partition_for(@partitioners)
+    |> Utils.partition_for(partitioners())
     |> partitioner_for
   end
 

--- a/lib/manifold.ex
+++ b/lib/manifold.ex
@@ -16,7 +16,7 @@ defmodule Manifold do
   @workers_per_partitioner Application.get_env(:manifold, :workers_per_partitioner, System.schedulers_online)
 
   @max_senders 128
-  @senders min(Application.get_env(:manifold, :senders, System.schedulers_online), @max_senders)
+  def senders(), do: min(Application.get_env(:manifold, :senders, System.schedulers_online), @max_senders)
 
   ## OTP
 


### PR DESCRIPTION
Make number of number senders, partitioners and workers configurable at runtime, not just at compile time (eg. if you build on one machine but would like to run the application on another, the number of online schedulers might be incorrect without this fix)