### PR TITLE
Runtime configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,14 +76,37 @@ Manifold.send(self(), :hello, send_mode: :offload)
 
 ### Configuration
 
-Manifold takes a single configuration option, which sets the module it dispatches to actually call send. The default
-is GenServer. To set this variable, add the following to your `config.exs`:
+Manifold reads the following application environment options, which can be set in your `config.exs`. All of them are
+optional; Manifold applies sensible runtime defaults when they are not set, so only configure the ones you want to
+override:
 
 ```elixir
-config :manifold, gen_module: MyGenModule
+config :manifold,
+  gen_module: MyGenModule,
+  partitioners: 1,
+  workers_per_partitioner: 8,
+  senders: 8
 ```
 
-In the above instance, `MyGenModule` must define a `cast/2` function that matches the types of `GenServer.cast`.
+#### gen_module
+
+Sets the module that Manifold dispatches to in order to actually call send. The default is `GenServer`. The configured
+module must define a `cast/2` function that matches the types of `GenServer.cast/2`.
+
+#### partitioners
+
+The number of `Manifold.Partitioner` processes to run per node. Defaults to `1` and is capped at `32`. Increasing this
+spreads partitioning work across more processes so the partitioner does not become a bottleneck.
+
+#### workers_per_partitioner
+
+The number of child workers each partitioner uses to send to the actual PIDs. Defaults to `System.schedulers_online()`
+(the number of online schedulers, typically the number of cores).
+
+#### senders
+
+The size of the `Manifold.Sender` pool used when sending with `send_mode: :offload` (see [send_mode](#send_mode)).
+Defaults to `System.schedulers_online()` and is capped at `128`.
 
 
 ## License

--- a/lib/manifold.ex
+++ b/lib/manifold.ex
@@ -12,28 +12,16 @@ defmodule Manifold do
   @type option :: pack_mode_option() | send_mode_option()
 
   @max_partitioners 32
-  @partitioners min(Application.get_env(:manifold, :partitioners, 1), @max_partitioners)
-  @workers_per_partitioner Application.get_env(:manifold, :workers_per_partitioner, System.schedulers_online)
-
   @max_senders 128
-  @senders min(Application.get_env(:manifold, :senders, System.schedulers_online), @max_senders)
 
   ## OTP
 
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
 
-    partitioners =
-      for partitioner_id <- 0..(@partitioners - 1) do
-        Partitioner.child_spec(@workers_per_partitioner, name: partitioner_for(partitioner_id))
-      end
+    setup_config()
 
-    senders =
-      for sender_id <- 0..(@senders - 1) do
-        Sender.child_spec(name: sender_for(sender_id))
-      end
-
-    Supervisor.start_link(partitioners ++ senders,
+    Supervisor.start_link(partitioner_children() ++ sender_children(),
       strategy: :one_for_one,
       max_restarts: 10,
       name: __MODULE__.Supervisor
@@ -47,7 +35,7 @@ defmodule Manifold do
     valid_options = [
       {:pack_mode, :binary},
       {:pack_mode, :etf},
-      {:send_mode, :offload},
+      {:send_mode, :offload}
     ]
 
     # Keywords could have duplicate keys, in which case the first key wins.
@@ -107,10 +95,13 @@ defmodule Manifold do
   def send(nil, _message, _options), do: :ok
 
   def set_partitioner_key(key) do
-    partitioner = key
-    |> Utils.hash()
-    |> rem(@partitioners)
-    |> partitioner_for()
+    partitioners = lookup_config(:partitioners)
+
+    partitioner =
+      key
+      |> Utils.hash()
+      |> rem(partitioners)
+      |> partitioner_for()
 
     Process.put(:manifold_partitioner, partitioner)
   end
@@ -119,31 +110,37 @@ defmodule Manifold do
     case Process.get(:manifold_partitioner) do
       nil ->
         partitioner_for(self())
+
       partitioner ->
         partitioner
     end
   end
 
   def partitioner_for(pid) when is_pid(pid) do
+    partitioners = lookup_config(:partitioners)
+
     pid
-    |> Utils.partition_for(@partitioners)
+    |> Utils.partition_for(partitioners)
     |> partitioner_for
   end
 
   # The 0th partitioner does not have a number in it's process name for backwards compatibility
   # purposes.
   def partitioner_for(0), do: Manifold.Partitioner
-  for partitioner_id <- (1..@max_partitioners - 1) do
+
+  for partitioner_id <- 1..(@max_partitioners - 1) do
     def partitioner_for(unquote(partitioner_id)) do
       unquote(:"Manifold.Partitioner_#{partitioner_id}")
     end
   end
 
   def set_sender_key(key) do
+    senders = lookup_config(:senders)
+
     sender =
       key
       |> Utils.hash()
-      |> rem(@senders)
+      |> rem(senders)
       |> sender_for()
 
     Process.put(:manifold_sender, sender)
@@ -160,14 +157,57 @@ defmodule Manifold do
   end
 
   def sender_for(pid) when is_pid(pid) do
+    senders = lookup_config(:senders)
+
     pid
-    |> Utils.partition_for(@senders)
+    |> Utils.partition_for(senders)
     |> sender_for
   end
 
   for sender_id <- 0..(@max_senders - 1) do
     def sender_for(unquote(sender_id)) do
       unquote(:"Manifold.Sender_#{sender_id}")
+    end
+  end
+
+  defp setup_config() do
+    partitioners = min(Application.get_env(:manifold, :partitioners, 1), @max_partitioners)
+
+    workers_per_partitioner =
+      Application.get_env(:manifold, :workers_per_partitioner, System.schedulers_online())
+
+    senders =
+      min(Application.get_env(:manifold, :senders, System.schedulers_online()), @max_senders)
+
+    :persistent_term.put(config_key(:partitioners), partitioners)
+    :persistent_term.put(config_key(:workers_per_partitioner), workers_per_partitioner)
+    :persistent_term.put(config_key(:senders), senders)
+  end
+
+  defp lookup_config(name) do
+    name
+    |> config_key()
+    |> :persistent_term.get()
+  end
+
+  defp config_key(name) do
+    :"Config.For.Manifold.#{name}"
+  end
+
+  defp partitioner_children() do
+    partitioners = lookup_config(:partitioners)
+    workers_per_partitioner = lookup_config(:workers_per_partitioner)
+
+    for partitioner_id <- 0..(partitioners - 1) do
+      Partitioner.child_spec(workers_per_partitioner, name: partitioner_for(partitioner_id))
+    end
+  end
+
+  defp sender_children() do
+    senders = lookup_config(:senders)
+
+    for sender_id <- 0..(senders - 1) do
+      Sender.child_spec(name: sender_for(sender_id))
     end
   end
 end

--- a/lib/manifold.ex
+++ b/lib/manifold.ex
@@ -28,6 +28,19 @@ defmodule Manifold do
     )
   end
 
+  ## Config Macros
+
+  defmacrop config_key(name) do
+    :"Config.For.Manifold.#{name}"
+  end
+
+  defmacrop lookup_config(name) do
+    quote do
+      key = config_key(unquote(name))
+      :persistent_term.get(key)
+    end
+  end
+
   ## Client
 
   @spec valid_send_options?(Keyword.t()) :: boolean()
@@ -182,16 +195,6 @@ defmodule Manifold do
     :persistent_term.put(config_key(:partitioners), partitioners)
     :persistent_term.put(config_key(:workers_per_partitioner), workers_per_partitioner)
     :persistent_term.put(config_key(:senders), senders)
-  end
-
-  defp lookup_config(name) do
-    name
-    |> config_key()
-    |> :persistent_term.get()
-  end
-
-  defp config_key(name) do
-    :"Config.For.Manifold.#{name}"
   end
 
   defp partitioner_children() do

--- a/mix.exs
+++ b/mix.exs
@@ -4,10 +4,10 @@ defmodule Manifold.Mixfile do
   def project do
     [
       app: :manifold,
-      version: "1.6.0",
-      elixir: "~> 1.5",
-      build_embedded: Mix.env == :prod,
-      start_permanent: Mix.env == :prod,
+      version: "1.7.0",
+      elixir: "~> 1.15",
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
       deps: deps(),
       package: package(),
       elixirc_paths: elixirc_paths(Mix.env())
@@ -17,13 +17,13 @@ defmodule Manifold.Mixfile do
   def application do
     [
       applications: [:logger],
-      mod: {Manifold, []},
+      mod: {Manifold, []}
     ]
   end
 
   defp deps do
     [
-      {:benchfella, "~> 0.3.0", only: [:dev, :test], runtime: false},
+      {:benchfella, "~> 0.3.0", only: [:dev, :test], runtime: false}
     ]
   end
 
@@ -43,8 +43,8 @@ defmodule Manifold.Mixfile do
       licenses: ["MIT"],
       files: ["lib/*", "mix.exs", "README*", "LICENSE*"],
       links: %{
-        "GitHub" => "https://github.com/discordapp/manifold",
-      },
+        "GitHub" => "https://github.com/discordapp/manifold"
+      }
     ]
   end
 end


### PR DESCRIPTION
Currently, there's no way to configure the partitoners/workers/senders at runtime; some of these settings were only read at app-startup (for setting up the children), and at other times were read as needed.

OTP 21 added [`persistent_term`](https://www.erlang.org/doc/apps/erts/persistent_term.html), which is extremely cheap to read from (cheaper than ETS/the app env, even), which we initialize at app startup and then read from as needed. This lets us ensure the values are in sync at startup and at runtime.

I've also bumped the elixir version here because of this (no one should be using 1.6 anymore...).